### PR TITLE
Added version number to mindagap.py for nf-core module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,17 @@ Use the extra script, like this:
 
 Docker  
 -----------
-To use MindaGap with Docker, you can follow the steps below to build the Docker image and then execute the script using a docker container with all required dependencies available:
+To use MindaGap with Docker, you can pull the prebuild docker image from Dockerhub or follow the steps below to build the Docker image.
+
+You can then execute the script using a docker container with all required dependencies available:
 
 ```
+## Pull the prebuild docker image from Docker hub
+docker pull rguerr/mindagap:latest
+```
+
+```
+#### To build the docker image yourself
 ## Clone this git repository
 git clone https://github.com/ViriatoII/MindaGap.git
 cd MindaGap

--- a/mindagap.py
+++ b/mindagap.py
@@ -58,19 +58,24 @@ if __name__ == '__main__':
 
     #increase max allowed image size
     os.environ["OPENCV_IO_MAX_IMAGE_PIXELS"] = pow(2,40).__str__()
+    
+    version_number = "0.0.1"
 
     import tifffile, cv2  
-   
 
     parser = argparse.ArgumentParser(description="Takes a single panorama image and fills the empty grid lines with neighbour-weighted values" )
     parser.add_argument("input", help="Input tif/png file with grid lines to fill")
     parser.add_argument("s", nargs = '?', type=int, default = 5,  help="Box size for gaussian kernel (bigger better for big gaps but less accurate)")
     parser.add_argument("r", nargs = '?', type=int, default = 40, help="Number of rounds to apply gaussianBlur (more is better)")
     parser.add_argument("-e", '--edges', nargs = '?', default = False, help="Also smooth edges near grid lines")
+    parser.add_argument("-v", '--version', action=argparse.BooleanOptionalAction, default = False, help="Print version number.")
     args=parser.parse_args()
 
     if args.s % 2 == 0:
         print("-s argument must be uneven number") ; exit()
+        
+    if args.version:
+        print(version_number) ; exit()
 
     # Sanity checks of input
     pathname, extension = os.path.splitext(args.input)


### PR DESCRIPTION
Hi @ViriatoII ,

So sorry, I thought I could add this before you merged the last PR. Nf-core modules require the tool to output a version number to track which versions are run. I added a very quick option to have mindagap.py output the version number stored in $version_number if provided with the -v flag. This way, I could easily parse it from the tool itself in the nextflow module code.