### PR TITLE
make compatible with python versions <3.9

### DIFF
--- a/mindagap.py
+++ b/mindagap.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser.add_argument("-xt", "--Xtilesize", nargs = '?', type=int, default = None,  help="Tile size (distance between gridlines) on X axis")
     parser.add_argument("-yt", "--Ytilesize", nargs = '?', type=int, default = None,  help="Tile size (distance between gridlines) on Y axis")
     parser.add_argument("-e", '--edges', nargs = '?', default = False, help="Also smooth edges near grid lines")
-    parser.add_argument("-v", '--version', action=argparse.BooleanOptionalAction, default = False, help="Print version number.")
+    parser.add_argument("-v", '--version', action='store_true', default=False, help="Print version number.")
     args=parser.parse_args()
 
     if args.s % 2 == 0:


### PR DESCRIPTION
using in python v3.8 gives following error message
```
nmq407@/projects/petar/fgf1/01_resolve$ python /projects/petar/fgf1/code/MindaGap/mindagap.py microscope_image.tiff 3 40 --edges False
Traceback (most recent call last):
  File "/projects/petar/fgf1/code/MindaGap/mindagap.py", line 110, in <module>
    parser.add_argument("-v", '--version', action=argparse.BooleanOptionalAction, default = False, help="Print version number.")
AttributeError: module 'argparse' has no attribute 'BooleanOptionalAction'
```

This is because `BooleanOptionalAction` class was added to the argparse module in Python 3.9. The behavior can be preserved and made compatible with older versions with the proposed change.